### PR TITLE
Rails 8 support

### DIFF
--- a/lib/twitter/bootstrap/rails/version.rb
+++ b/lib/twitter/bootstrap/rails/version.rb
@@ -1,7 +1,7 @@
 module Twitter
   module Bootstrap
     module Rails
-      VERSION = "5.0.0"
+      VERSION = "5.1.0"
     end
   end
 end

--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'railties', '>= 5.0', '< 8.0'
-  s.add_dependency 'actionpack', '>= 5.0', '< 8.0'
+  s.add_dependency 'railties', '>= 5.0', '<= 8.0'
+  s.add_dependency 'actionpack', '>= 5.0', '<= 8.0'
   s.add_dependency 'less-rails', '>= 3.0', '< 5.0'
 
   s.add_runtime_dependency 'execjs', '~> 2.7'

--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'railties', '>= 5.0', '<= 8.0'
-  s.add_dependency 'actionpack', '>= 5.0', '<= 8.0'
+  s.add_dependency 'railties', '>= 5.0', '< 9.0'
+  s.add_dependency 'actionpack', '>= 5.0', '< 9.0'
   s.add_dependency 'less-rails', '>= 3.0', '< 5.0'
 
   s.add_runtime_dependency 'execjs', '~> 2.7'


### PR DESCRIPTION
We are blocked from upgrading to Rails 8 by this gem. In order to make this gem compatible, I updated the `actionpack` and `railties` dependencies in `twitter-bootstrap-rails.gemspec` to `'>= 5.0', '< 9.0'`

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.
